### PR TITLE
Add make entry for ARM arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,8 @@ buildWindows386:
 
 buildWindowsAmd64:
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o dist/portchecker-windows-amd64.exe ./portchecker.go
+
+buildLinuxArm:
+	docker run --rm -v ${PWD}:/app/ -e CGO_ENABLED=0 -e GOOS=linux -e GOARCH=arm -w=/app/ golang:latest  go build -o dist/portchecker-linux-arm ./portchecker.go
+
+


### PR DESCRIPTION
I'd added an entry at Makefile to build portchecker for armv7. Te entry use docker, to be able to run it on every raspberry without installing all go dependencies. I'm using this arm relase to build an image of codimd for running into a kubernetes cluter in a raspberry pi. 